### PR TITLE
Rewriting dispatcher and connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [0.0.10] - 2023-09-234
+## [0.0.10] - 2023-10-04
 ### Added
- - `dispatcher_internal_queue_size` parameter to builder, allowing to customize size of internal queue between dispatcher and connection.
+ - `internal_simultaneous_requests_threshold` parameter to builder, which allow to customize maximum number of simultaneously created requests, which connection can effectively handle.
+
+### Changed
+ - Rewritten internal logic of connection to Tarantool, which improved performance separated reading and writing to socket into separate tasks.
 
 ### Fixed
- - Increased size of internal queue between dispatcher and connection, which should significantly increase performance (previously it was degrading rapidly with a lot of parallel requests).
+ - Increased size of internal channel between dispatcher and connection, which should significantly increase performance (previously it was degrading rapidly with a lot of concurrent requests).
 
 
 ## [0.0.9] - 2023-09-23 (broken, yanked)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [0.0.9] - 2023-09-23
+## [0.0.10] - 2023-09-234
 ### Added
  - `dispatcher_internal_queue_size` parameter to builder, allowing to customize size of internal queue between dispatcher and connection.
 
 ### Fixed
  - Increased size of internal queue between dispatcher and connection, which should significantly increase performance (previously it was degrading rapidly with a lot of parallel requests).
+
+
+## [0.0.9] - 2023-09-23 (broken, yanked)
 
 
 ## [0.0.8] - 2023-09-05

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tarantool-rs"
 description = "Asyncronous tokio-based client for Tarantool"
-version = "0.0.9"
+version = "0.0.10"
 edition = "2021"
 authors = ["Andrey Kononov flowneee3@gmail.com"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ serde = { version = "1", features = ["derive"] }
 sha-1 = "0.10"
 thiserror = "1"
 tokio = { version = "1", features = ["rt", "net", "io-util", "macros", "time"] }
+tokio-stream = "0.1.14"
 tokio-util = { version = "0.7", default-features = false, features = ["codec"] }
 tracing = { version = "0.1", features = ["log"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ async-trait = "0.1"
 backoff = "0.4"
 base64 = "0.21"
 bytes = "1"
-futures = { version = "0.3", features = ["unstable", "bilock"] }
+futures = "0.3"
 lru = "0.11"
 parking_lot = { version = "0.12", features = ["send_guard"] }
 rmp = "0.8"
@@ -26,7 +26,7 @@ serde = { version = "1", features = ["derive"] }
 sha-1 = "0.10"
 thiserror = "1"
 tokio = { version = "1", features = ["rt", "net", "io-util", "macros", "time"] }
-tokio-stream = "0.1.14"
+tokio-stream = "0.1"
 tokio-util = { version = "0.7", default-features = false, features = ["codec"] }
 tracing = { version = "0.1", features = ["log"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ async-trait = "0.1"
 backoff = "0.4"
 base64 = "0.21"
 bytes = "1"
-futures = "0.3"
+futures = { version = "0.3", features = ["unstable", "bilock"] }
 lru = "0.11"
 parking_lot = { version = "0.12", features = ["send_guard"] }
 rmp = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ serde_json = "1"
 tokio = { version = "1", features = ["full"] }
 tracing-test = { version = "0.2", features = ["no-env-filter"] }
 tarantool-test-container = { path = "tarantool-test-container" }
+rusty_tarantool = "*"
 
 [[example]]
 name = "cli_client"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,3 +62,7 @@ harness = false
 [[bench]]
 name = "compare"
 harness = false
+
+[[bench]]
+name = "simple_loop"
+harness = false

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -26,7 +26,7 @@ pub fn bench_tarantool_rs(c: &mut Criterion) {
     // Bench logic
     // NOTE: on my PC converting to join add slight overhead (1-2 microseconds for 1 future input)
     // NOTE: on my PC 50 input load tarantool to 50% on single core
-    for parallel in [1, 2, 5, 10, 50].into_iter() {
+    for parallel in [1, 5, 10, 50].into_iter() {
         group.bench_with_input(BenchmarkId::new("ping", parallel), &parallel, |b, p| {
             b.to_async(&tokio_rt).iter(|| async {
                 let make_fut = |_| conn.ping();

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -26,7 +26,7 @@ pub fn bench_tarantool_rs(c: &mut Criterion) {
     // Bench logic
     // NOTE: on my PC converting to join add slight overhead (1-2 microseconds for 1 future input)
     // NOTE: on my PC 50 input load tarantool to 50% on single core
-    for parallel in [1, 5, 10, 50].into_iter() {
+    for parallel in [1000].into_iter() {
         group.bench_with_input(BenchmarkId::new("ping", parallel), &parallel, |b, p| {
             b.to_async(&tokio_rt).iter(|| async {
                 let make_fut = |_| conn.ping();

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -26,7 +26,7 @@ pub fn bench_tarantool_rs(c: &mut Criterion) {
     // Bench logic
     // NOTE: on my PC converting to join add slight overhead (1-2 microseconds for 1 future input)
     // NOTE: on my PC 50 input load tarantool to 50% on single core
-    for parallel in [1, 50, 250, 1000].into_iter() {
+    for parallel in [1000].into_iter() {
         group.bench_with_input(BenchmarkId::new("ping", parallel), &parallel, |b, p| {
             b.to_async(&tokio_rt).iter(|| async {
                 let make_fut = |_| conn.ping();

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -26,7 +26,7 @@ pub fn bench_tarantool_rs(c: &mut Criterion) {
     // Bench logic
     // NOTE: on my PC converting to join add slight overhead (1-2 microseconds for 1 future input)
     // NOTE: on my PC 50 input load tarantool to 50% on single core
-    for parallel in [1000].into_iter() {
+    for parallel in [1, 50, 250, 1000].into_iter() {
         group.bench_with_input(BenchmarkId::new("ping", parallel), &parallel, |b, p| {
             b.to_async(&tokio_rt).iter(|| async {
                 let make_fut = |_| conn.ping();

--- a/benches/compare.rs
+++ b/benches/compare.rs
@@ -31,7 +31,7 @@ pub fn compare_tarantool_rs_and_rusty_tarantool(c: &mut Criterion) {
     // Bench logic
     // NOTE: on my PC converting to join add slight overhead (1-2 microseconds for 1 future input)
     // NOTE: on my PC 50 input load tarantool to 50% on single core
-    for parallel in [1, 2, 5, 10, 50].into_iter() {
+    for parallel in [1, 50, 250, 1000].into_iter() {
         group.bench_with_input(
             BenchmarkId::new("tarantool_rs ping", parallel),
             &parallel,

--- a/benches/compare.rs
+++ b/benches/compare.rs
@@ -31,7 +31,7 @@ pub fn compare_tarantool_rs_and_rusty_tarantool(c: &mut Criterion) {
     // Bench logic
     // NOTE: on my PC converting to join add slight overhead (1-2 microseconds for 1 future input)
     // NOTE: on my PC 50 input load tarantool to 50% on single core
-    for parallel in [1, 50, 250, 1000].into_iter() {
+    for parallel in [1, 2, 5, 10, 50].into_iter() {
         group.bench_with_input(
             BenchmarkId::new("tarantool_rs ping", parallel),
             &parallel,

--- a/benches/simple_loop.rs
+++ b/benches/simple_loop.rs
@@ -1,0 +1,48 @@
+use std::time::{Duration, Instant};
+
+use futures::{stream::repeat_with, StreamExt};
+use tarantool_rs::{Connection, ExecutorExt};
+
+type TarantoolTestContainer = tarantool_test_container::TarantoolTestContainer<
+    tarantool_test_container::TarantoolDefaultArgs,
+>;
+
+#[tokio::main]
+async fn main() -> Result<(), anyhow::Error> {
+    let container = TarantoolTestContainer::default();
+
+    let conn = Connection::builder()
+        .dispatcher_internal_queue_size(15000)
+        .build(format!("127.0.0.1:{}", container.connect_port()))
+        .await?;
+    let conn = rusty_tarantool::tarantool::ClientConfig::new(
+        format!("127.0.0.1:{}", container.connect_port()),
+        "guest",
+        "",
+    )
+    .build();
+    conn.ping().await?;
+
+    let mut counter = 0u64;
+    let mut last_measured_counter = 0;
+    let mut last_measured_ts = Instant::now();
+
+    let interval_secs = 2;
+    let interval = Duration::from_secs(interval_secs);
+
+    let mut stream = repeat_with(|| conn.ping()).buffer_unordered(10000);
+    while let _ = stream.next().await {
+        counter += 1;
+        if last_measured_ts.elapsed() > interval {
+            last_measured_ts = Instant::now();
+            let counter_diff = counter - last_measured_counter;
+            last_measured_counter = counter;
+            println!(
+                "Iterations over last {interval_secs} seconds: {counter_diff}, per second: {}",
+                counter_diff / interval_secs
+            );
+        }
+    }
+
+    Ok(())
+}

--- a/benches/simple_loop.rs
+++ b/benches/simple_loop.rs
@@ -12,16 +12,16 @@ async fn main() -> Result<(), anyhow::Error> {
     let container = TarantoolTestContainer::default();
 
     let conn = Connection::builder()
-        .dispatcher_internal_queue_size(15000)
+        .dispatcher_internal_queue_size(1100)
         .build(format!("127.0.0.1:{}", container.connect_port()))
         .await?;
-    let conn = rusty_tarantool::tarantool::ClientConfig::new(
-        format!("127.0.0.1:{}", container.connect_port()),
-        "guest",
-        "",
-    )
-    .build();
-    conn.ping().await?;
+    // let conn = rusty_tarantool::tarantool::ClientConfig::new(
+    //     format!("127.0.0.1:{}", container.connect_port()),
+    //     "guest",
+    //     "",
+    // )
+    // .build();
+    // conn.ping().await?;
 
     let mut counter = 0u64;
     let mut last_measured_counter = 0;
@@ -30,7 +30,7 @@ async fn main() -> Result<(), anyhow::Error> {
     let interval_secs = 2;
     let interval = Duration::from_secs(interval_secs);
 
-    let mut stream = repeat_with(|| conn.ping()).buffer_unordered(10000);
+    let mut stream = repeat_with(|| conn.ping()).buffer_unordered(1000);
     while let _ = stream.next().await {
         counter += 1;
         if last_measured_ts.elapsed() > interval {

--- a/benches/simple_loop.rs
+++ b/benches/simple_loop.rs
@@ -12,7 +12,7 @@ async fn main() -> Result<(), anyhow::Error> {
     let container = TarantoolTestContainer::default();
 
     let conn = Connection::builder()
-        .dispatcher_internal_queue_size(1100)
+        .internal_simultaneous_requests_threshold(1000)
         .build(format!("127.0.0.1:{}", container.connect_port()))
         .await?;
     // let conn = rusty_tarantool::tarantool::ClientConfig::new(

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -98,6 +98,7 @@ impl ConnectionBuilder {
             self.password.as_deref(),
             self.timeout,
             self.reconnect_interval.clone(),
+            self.dispatcher_internal_queue_size,
         )
         .await?;
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -92,7 +92,7 @@ impl ConnectionBuilder {
     where
         A: ToSocketAddrs + Display + Clone + Send + Sync + 'static,
     {
-        let (dispatcher, disaptcher_sender) = Dispatcher::new(
+        let (dispatcher_fut, disaptcher_sender) = Dispatcher::new(
             addr,
             self.user.as_deref(),
             self.password.as_deref(),
@@ -103,7 +103,7 @@ impl ConnectionBuilder {
         .await?;
 
         // TODO: support setting custom executor
-        tokio::spawn(dispatcher.run());
+        tokio::spawn(dispatcher_fut);
         let conn = Connection::new(
             disaptcher_sender,
             self.timeout,

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -67,7 +67,7 @@ pub struct ConnectionBuilder {
     connect_timeout: Option<Duration>,
     reconnect_interval: Option<ReconnectInterval>,
     sql_statement_cache_capacity: usize,
-    dispatcher_internal_queue_size: usize,
+    internal_simultaneous_requests_threshold: usize,
 }
 
 impl Default for ConnectionBuilder {
@@ -81,7 +81,7 @@ impl Default for ConnectionBuilder {
             connect_timeout: None,
             reconnect_interval: Some(ReconnectInterval::default()),
             sql_statement_cache_capacity: DEFAULT_SQL_STATEMENT_CACHE_CAPACITY,
-            dispatcher_internal_queue_size: DEFAULT_DISPATCHER_INTERNAL_QUEUE_SIZE,
+            internal_simultaneous_requests_threshold: DEFAULT_DISPATCHER_INTERNAL_QUEUE_SIZE,
         }
     }
 }
@@ -92,13 +92,13 @@ impl ConnectionBuilder {
     where
         A: ToSocketAddrs + Display + Clone + Send + Sync + 'static,
     {
-        let (dispatcher_fut, disaptcher_sender) = Dispatcher::new(
+        let (dispatcher_fut, disaptcher_sender) = Dispatcher::prepare(
             addr,
             self.user.as_deref(),
             self.password.as_deref(),
             self.timeout,
             self.reconnect_interval.clone(),
-            self.dispatcher_internal_queue_size,
+            self.internal_simultaneous_requests_threshold,
         )
         .await?;
 
@@ -195,16 +195,20 @@ impl ConnectionBuilder {
         self
     }
 
-    /// Sets size of the internal queue between connection and dispatcher.
+    /// Prepare `Connection` to process `value` number of simultaneously created requests.
     ///
-    /// This queue contains all requests, made from [`Connection`]s/[`Stream`]s/etc.
-    /// Increasing its size can help if you have a lot of requests, made concurrently
-    /// and frequently, however this will increase memory consumption slightly.
+    /// It is not hard limit, but making more simultaneous requests than this value
+    /// will result in degradation in performance, so try to increase this value,
+    /// if you unsatisfied with performance.
+    ///
+    /// Internally connection have multiple bounded channels, and this parameter mostly
+    /// affect size of this channels. Increasing this value can help if you have a lot of simultaneously
+    /// created requests, however this will increase memory consumption.
     ///
     /// By default set to 500, which should be reasonable compromise between memory
-    /// (about 50 KB) and performance.
-    pub fn dispatcher_internal_queue_size(&mut self, size: usize) -> &mut Self {
-        self.dispatcher_internal_queue_size = size;
+    /// (about 100 KB) and performance.
+    pub fn internal_simultaneous_requests_threshold(&mut self, value: usize) -> &mut Self {
+        self.internal_simultaneous_requests_threshold = value;
         self
     }
 }

--- a/src/transport/connection.rs
+++ b/src/transport/connection.rs
@@ -8,11 +8,17 @@ use std::{
 use futures::{SinkExt, TryStreamExt};
 use tokio::{
     io::AsyncReadExt,
-    net::{TcpStream, ToSocketAddrs},
-    sync::oneshot,
+    net::{
+        tcp::{OwnedReadHalf, OwnedWriteHalf},
+        TcpStream, ToSocketAddrs,
+    },
+    sync::{mpsc, oneshot},
 };
-use tokio_util::codec::Framed;
-use tracing::{debug, trace, warn};
+use tokio_util::{
+    codec::{Framed, FramedParts, FramedRead, FramedWrite},
+    sync::{CancellationToken, DropGuard},
+};
+use tracing::{debug, error, trace, warn};
 
 use super::dispatcher::DispatcherResponse;
 use crate::{
@@ -24,10 +30,25 @@ use crate::{
     errors::{CodecDecodeError, CodecEncodeError, Error},
 };
 
+async fn write_loop(
+    mut rx: mpsc::Receiver<EncodedRequest>,
+    mut writer: FramedWrite<OwnedWriteHalf, ClientCodec>,
+    cancellation_token: CancellationToken,
+) {
+    while let Some(next) = rx.recv().await {
+        if let Err(err) = writer.send(next).await {
+            error!("Failed to write message to TCP connection: {err:?}");
+            return;
+        }
+    }
+}
+
 pub(crate) struct Connection {
-    stream: Framed<TcpStream, ClientCodec>,
+    reader: FramedRead<OwnedReadHalf, ClientCodec>,
+    writer_tx: mpsc::Sender<EncodedRequest>,
     in_flights: HashMap<u32, oneshot::Sender<DispatcherResponse>>,
     next_sync: AtomicU32,
+    _drop_guard: DropGuard,
 }
 
 // TODO: cancel
@@ -41,19 +62,32 @@ impl Connection {
         A: ToSocketAddrs + Display,
     {
         debug!("Starting connection to Tarantool {}", addr);
-        let mut tcp = TcpStream::connect(&addr).await?;
+        let tcp = TcpStream::connect(&addr).await?;
         trace!("Connection established to {}", addr);
+        let (mut read_stream, write_stream) = tcp.into_split();
 
         let mut greeting_buffer = [0u8; Greeting::SIZE];
-        tcp.read_exact(&mut greeting_buffer).await?;
+        read_stream.read_exact(&mut greeting_buffer).await?;
         let greeting = Greeting::decode(greeting_buffer)?;
         debug!("Server: {}", greeting.server);
         trace!("Salt: {:?}", greeting.salt);
 
+        let reader = FramedRead::new(read_stream, ClientCodec::default());
+        let writer = FramedWrite::new(write_stream, ClientCodec::default());
+
+        let cancellation_token = CancellationToken::new();
+        let drop_guard = cancellation_token.clone().drop_guard();
+
+        let (writer_tx, writer_rx) = mpsc::channel(500);
+
+        let _ = tokio::spawn(write_loop(writer_rx, writer, cancellation_token));
+
         let mut this = Self {
-            stream: Framed::new(tcp, ClientCodec::default()),
+            reader,
+            writer_tx,
             in_flights: HashMap::with_capacity(5),
             next_sync: AtomicU32::new(0),
+            _drop_guard: drop_guard,
         };
 
         if let Some(user) = user {
@@ -86,7 +120,9 @@ impl Connection {
         *request.sync_mut() = self.next_sync();
 
         trace!("Sending auth request");
-        self.stream.send(request).await?;
+        if let Err(_) = self.writer_tx.send(request).await {
+            panic!("Failed to send to interal writer channel (auth)");
+        };
 
         let resp = self.get_next_stream_value().await?;
         match resp.body {
@@ -128,21 +164,24 @@ impl Connection {
             }
             return Ok(());
         }
-        match self.stream.send(request).await {
+        match self.writer_tx.send(request).await {
             Ok(x) => Ok(x),
-            Err(CodecEncodeError::Encode(err)) => {
-                if self
-                    .in_flights
-                    .remove(&sync)
-                    .expect("Shouldn't panic, value was just inserted")
-                    .send(Err(err.into()))
-                    .is_err()
-                {
-                    warn!("Failed to pass error to sync {}, receiver dropped", sync);
-                }
-                Ok(())
+            // Err(CodecEncodeError::Encode(err)) => {
+            //     if self
+            //         .in_flights
+            //         .remove(&sync)
+            //         .expect("Shouldn't panic, value was just inserted")
+            //         .send(Err(err.into()))
+            //         .is_err()
+            //     {
+            //         warn!("Failed to pass error to sync {}, receiver dropped", sync);
+            //     }
+            //     Ok(())
+            // }
+            // Err(CodecEncodeError::Io(err)) => Err(err),
+            Err(_) => {
+                panic!("Failed to send to interal writer channel");
             }
-            Err(CodecEncodeError::Io(err)) => Err(err),
         }
     }
 
@@ -158,7 +197,7 @@ impl Connection {
     }
 
     async fn get_next_stream_value(&mut self) -> Result<Response, CodecDecodeError> {
-        match self.stream.try_next().await {
+        match self.reader.try_next().await {
             Ok(Some(x)) => Ok(x),
             Ok(None) => Err(CodecDecodeError::Closed),
             Err(e) => Err(e),

--- a/src/transport/connection.rs
+++ b/src/transport/connection.rs
@@ -1,11 +1,6 @@
-use std::{
-    collections::HashMap,
-    fmt::Display,
-    sync::atomic::{AtomicU32, Ordering},
-    time::Duration,
-};
+use std::{collections::HashMap, fmt::Display, time::Duration};
 
-use futures::{future::pending, Future, SinkExt, TryStreamExt};
+use futures::{future::pending, SinkExt, TryStreamExt};
 use tokio::{
     io::AsyncReadExt,
     net::{
@@ -16,7 +11,7 @@ use tokio::{
     sync::{mpsc, oneshot},
 };
 use tokio_util::{
-    codec::{Framed, FramedRead, FramedWrite},
+    codec::{FramedRead, FramedWrite},
     either::Either,
 };
 use tracing::{debug, trace, warn};
@@ -31,11 +26,91 @@ use crate::{
     errors::{CodecDecodeError, CodecEncodeError, Error},
 };
 
-pub(crate) struct Connection {
-    read_stream: Option<FramedRead<OwnedReadHalf, ClientCodec>>,
-    write_stream: Option<FramedWrite<OwnedWriteHalf, ClientCodec>>,
+struct ConnectionData {
     in_flights: HashMap<u32, oneshot::Sender<DispatcherResponse>>,
     next_sync: u32,
+}
+
+impl Default for ConnectionData {
+    fn default() -> Self {
+        Self {
+            in_flights: HashMap::with_capacity(5),
+            next_sync: 0,
+        }
+    }
+}
+
+impl ConnectionData {
+    #[inline]
+    fn next_sync(&mut self) -> u32 {
+        let next = self.next_sync;
+        self.next_sync += 1;
+        next
+    }
+
+    /// Prepare request for sending to server.
+    ///
+    /// Set `sync` value and attempt to store this message in in-flight storage.
+    ///
+    /// `Err` means that message was not prepared and should not be sent.
+    /// This function also take care of reporting error through `tx`.
+    #[inline]
+    fn try_prepare_request(
+        &mut self,
+        request: &mut EncodedRequest,
+        tx: oneshot::Sender<DispatcherResponse>,
+    ) -> Result<(), ()> {
+        let sync = self.next_sync();
+        *request.sync_mut() = sync;
+        trace!(
+            "Sending request with sync {}, stream_id {:?}",
+            request.sync,
+            request.stream_id
+        );
+        // TODO: replace with try_insert when stabilized
+        // If sync already assigned to another request, return an error
+        // for current request
+        if let Some(old) = self.in_flights.insert(request.sync, tx) {
+            let new = self
+                .in_flights
+                .insert(request.sync, old)
+                .expect("Shouldn't panic, value was just inserted");
+            if new.send(Err(Error::DuplicatedSync(request.sync))).is_err() {
+                warn!(
+                    "Failed to pass error to sync {}, receiver dropped",
+                    request.sync
+                );
+            }
+            return Err(());
+        }
+        Ok(())
+    }
+
+    /// Send result of processing request (by sync) to client.
+    #[inline]
+    fn respond_to_client(&mut self, sync: u32, result: Result<Response, Error>) {
+        if let Some(tx) = self.in_flights.remove(&sync) {
+            if tx.send(result).is_err() {
+                warn!("Failed to pass response sync {}, receiver dropped", sync);
+            }
+        } else {
+            warn!("Unknown sync {}", sync);
+        }
+    }
+
+    /// Send error to all in-flight requests and drop them.
+    #[inline]
+    fn send_error_to_all_in_flights(&mut self, err: CodecDecodeError) {
+        for (_, tx) in self.in_flights.drain() {
+            let _ = tx.send(Err(err.clone().into()));
+        }
+    }
+}
+
+pub(crate) struct Connection {
+    read_stream: FramedRead<OwnedReadHalf, ClientCodec>,
+    write_stream: FramedWrite<OwnedWriteHalf, ClientCodec>,
+    data: ConnectionData,
 }
 
 // TODO: cancel
@@ -62,11 +137,13 @@ impl Connection {
         let mut read_stream = FramedRead::new(read_tcp_stream, ClientCodec::default());
         let mut write_stream = FramedWrite::new(write_tcp_stream, ClientCodec::default());
 
+        let mut conn_data = ConnectionData::default();
+
         if let Some(user) = user {
             Self::auth(
                 &mut read_stream,
                 &mut write_stream,
-                0,
+                conn_data.next_sync(),
                 user,
                 password,
                 &greeting.salt,
@@ -75,10 +152,9 @@ impl Connection {
         }
 
         let this = Self {
-            read_stream: Some(read_stream),
-            write_stream: Some(write_stream),
-            in_flights: HashMap::with_capacity(5),
-            next_sync: 0,
+            read_stream,
+            write_stream,
+            data: conn_data,
         };
 
         Ok(this)
@@ -116,142 +192,31 @@ impl Connection {
         trace!("Sending auth request");
         write_stream.send(request).await?;
 
-        let resp = Self::get_next_stream_value2(read_stream).await?;
+        let resp = Self::get_next_stream_value(read_stream).await?;
         match resp.body {
             ResponseBody::Ok(_x) => Ok(()),
             ResponseBody::Error(err) => Err(Error::Auth(err)),
         }
     }
 
-    // TODO: maybe other Ordering??
-    fn next_sync(&mut self) -> u32 {
-        let next = self.next_sync;
-        self.next_sync += 1;
-        next
-    }
-
-    // pub(super) async fn send_request(
-    //     &mut self,
-    //     mut request: EncodedRequest,
-    //     tx: oneshot::Sender<DispatcherResponse>,
-    // ) -> Result<(), tokio::io::Error> {
-    //     let sync = self.next_sync();
-    //     *request.sync_mut() = sync;
-    //     trace!(
-    //         "Sending request with sync {}, stream_id {:?}",
-    //         request.sync,
-    //         request.stream_id
-    //     );
-    //     // TODO: replace with try_insert when stabilized
-    //     // If sync already assigned to another request, return an error
-    //     // for current request
-    //     if let Some(old) = self.in_flights.insert(request.sync, tx) {
-    //         let new = self
-    //             .in_flights
-    //             .insert(request.sync, old)
-    //             .expect("Shouldn't panic, value was just inserted");
-    //         if new.send(Err(Error::DuplicatedSync(request.sync))).is_err() {
-    //             warn!(
-    //                 "Failed to pass error to sync {}, receiver dropped",
-    //                 request.sync
-    //             );
-    //         }
-    //         return Ok(());
-    //     }
-    //     match self.write_stream.send(request).await {
-    //         Ok(x) => Ok(x),
-    //         Err(CodecEncodeError::Encode(err)) => {
-    //             if self
-    //                 .in_flights
-    //                 .remove(&sync)
-    //                 .expect("Shouldn't panic, value was just inserted")
-    //                 .send(Err(err.into()))
-    //                 .is_err()
-    //             {
-    //                 warn!("Failed to pass error to sync {}, receiver dropped", sync);
-    //             }
-    //             Ok(())
-    //         }
-    //         Err(CodecEncodeError::Io(err)) => Err(err),
-    //     }
-    // }
-
-    // Return false if request shouldn't be sent and should be dropped
-    // instead
-    fn prepare_request(
-        &mut self,
-        request: &mut EncodedRequest,
-        tx: oneshot::Sender<DispatcherResponse>,
-    ) -> bool {
-        let sync = self.next_sync();
-        *request.sync_mut() = sync;
-        trace!(
-            "Sending request with sync {}, stream_id {:?}",
-            request.sync,
-            request.stream_id
-        );
-        // TODO: replace with try_insert when stabilized
-        // If sync already assigned to another request, return an error
-        // for current request
-        if let Some(old) = self.in_flights.insert(request.sync, tx) {
-            let new = self
-                .in_flights
-                .insert(request.sync, old)
-                .expect("Shouldn't panic, value was just inserted");
-            if new.send(Err(Error::DuplicatedSync(request.sync))).is_err() {
-                warn!(
-                    "Failed to pass error to sync {}, receiver dropped",
-                    request.sync
-                );
-            }
-            return false;
-        }
-        true
-    }
-
+    #[inline]
     fn handle_send_result(
-        &mut self,
+        connection_data: &mut ConnectionData,
         sync: u32,
         result: Result<(), CodecEncodeError>,
     ) -> Result<(), tokio::io::Error> {
         match result {
             Ok(x) => Ok(x),
             Err(CodecEncodeError::Encode(err)) => {
-                if self
-                    .in_flights
-                    .remove(&sync)
-                    .expect("Shouldn't panic, value was just inserted")
-                    .send(Err(err.into()))
-                    .is_err()
-                {
-                    warn!("Failed to pass error to sync {}, receiver dropped", sync);
-                }
+                connection_data.respond_to_client(sync, Err(err.into()));
                 Ok(())
             }
             Err(CodecEncodeError::Io(err)) => Err(err),
         }
     }
 
-    fn pass_response(&mut self, response: Response) {
-        let sync = response.sync;
-        if let Some(tx) = self.in_flights.remove(&sync) {
-            if tx.send(Ok(response)).is_err() {
-                warn!("Failed to pass response sync {}, receiver dropped", sync);
-            }
-        } else {
-            warn!("Unknown sync {}", sync);
-        }
-    }
-
-    // async fn get_next_stream_value(&mut self) -> Result<Response, CodecDecodeError> {
-    //     match self.read_stream.try_next().await {
-    //         Ok(Some(x)) => Ok(x),
-    //         Ok(None) => Err(CodecDecodeError::Closed),
-    //         Err(e) => Err(e),
-    //     }
-    // }
-
-    async fn get_next_stream_value2(
+    #[inline]
+    async fn get_next_stream_value(
         read_stream: &mut FramedRead<OwnedReadHalf, ClientCodec>,
     ) -> Result<Response, CodecDecodeError> {
         match read_stream.try_next().await {
@@ -261,45 +226,36 @@ impl Connection {
         }
     }
 
-    // pub(super) async fn handle_next_response(&mut self) -> Result<(), CodecDecodeError> {
-    //     let resp = self.get_next_stream_value().await?;
-    //     trace!(
-    //         "Received response for sync {}, schema version {}",
-    //         resp.sync,
-    //         resp.schema_version
-    //     );
-    //     self.pass_response(resp);
-    //     Ok(())
-    // }
-
-    fn handle_response(&mut self, response: Response) {
+    #[inline]
+    fn handle_response(connection_data: &mut ConnectionData, response: Response) {
         trace!(
             "Received response for sync {}, schema version {}",
             response.sync,
             response.schema_version
         );
-        self.pass_response(response);
+        connection_data.respond_to_client(response.sync, Ok(response));
     }
 
-    /// Send error to all in flight requests and drop current transport.
-    pub(super) fn finish_with_error(&mut self, err: CodecDecodeError) {
-        for (_, tx) in self.in_flights.drain() {
-            let _ = tx.send(Err(err.clone().into()));
-        }
-    }
-
-    pub(crate) async fn run(mut self, rx: &mut mpsc::Receiver<DispatcherRequest>) -> bool {
-        let mut write_stream = self.write_stream.take();
-        let mut read_stream = self.read_stream.take().unwrap();
+    /// Run connection.
+    ///
+    /// `Ok` means `rx` was closed and connection should not be restarted.
+    /// `Err` means connection was dropped due to some error.
+    pub(crate) async fn run(self, rx: &mut mpsc::Receiver<DispatcherRequest>) -> Result<(), ()> {
+        let Self {
+            mut read_stream,
+            write_stream,
+            data: mut connection_data,
+        } = self;
+        let mut write_stream = Some(write_stream);
 
         let send_fut = Either::Left(pending());
         pin!(send_fut);
 
         let err = loop {
             tokio::select! {
-                next = Self::get_next_stream_value2(&mut read_stream) => {
+                next = Self::get_next_stream_value(&mut read_stream) => {
                     match next {
-                        Ok(x) => self.handle_response(x),
+                        Ok(x) => Self::handle_response(&mut connection_data, x),
                         Err(err) => break err,
                     }
                 }
@@ -308,7 +264,7 @@ impl Connection {
                         // Check whether tx is closed in case someone cancelled request
                         // while it was in queue
                         if !tx.is_closed() {
-                            if self.prepare_request(&mut request, tx) {
+                            if connection_data.try_prepare_request(&mut request, tx).is_ok() {
                                 let mut write_stream_ = write_stream.take().unwrap();
                                 send_fut.set(Either::Right(async move {
                                     let sync = request.sync;
@@ -319,20 +275,20 @@ impl Connection {
                         }
                     } else {
                         debug!("All senders dropped");
-                        return true
+                        return Ok(())
                     }
                 }
                 (send_res, sync, write_stream_) = &mut send_fut => {
                     send_fut.set(Either::Left(pending()));
                     write_stream = Some(write_stream_);
 
-                    if let Err(err) = self.handle_send_result(sync, send_res) {
+                    if let Err(err) = Self::handle_send_result(&mut connection_data, sync, send_res) {
                         break err.into();
                     }
                 }
             }
         };
-        self.finish_with_error(err);
-        false
+        connection_data.send_error_to_all_in_flights(err);
+        Err(())
     }
 }

--- a/src/transport/connection.rs
+++ b/src/transport/connection.rs
@@ -1,7 +1,9 @@
-use std::{collections::HashMap, fmt::Display, future::ready, sync::Arc, time::Duration};
+use std::{collections::HashMap, fmt::Display, future::ready, time::Duration};
 
-use futures::{future::pending, lock::BiLock, SinkExt, StreamExt, TryFutureExt, TryStreamExt};
-use parking_lot::Mutex;
+use futures::{
+    future::{Fuse, FusedFuture},
+    FutureExt, SinkExt, StreamExt, TryStreamExt,
+};
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
     net::{
@@ -16,21 +18,17 @@ use tokio::{
     task::JoinHandle,
 };
 use tokio_stream::wrappers::ReceiverStream;
-use tokio_util::{
-    codec::{FramedRead, FramedWrite},
-    either::Either,
-};
+use tokio_util::codec::{FramedRead, FramedWrite};
 use tracing::{debug, trace, warn};
 
 use super::dispatcher::{DispatcherRequest, DispatcherResponse};
 use crate::{
     codec::{
-        request::{self, Auth, EncodedRequest},
+        request::{Auth, EncodedRequest},
         response::{Response, ResponseBody},
         ClientCodec, Greeting,
     },
     errors::{CodecDecodeError, CodecEncodeError, Error},
-    transport::connection,
 };
 
 struct ConnectionData {
@@ -179,8 +177,9 @@ async fn writer_task(
 
 pub(crate) struct Connection {
     read_stream: FramedRead<OwnedReadHalf, ClientCodec>,
-    writer_tx: mpsc::Sender<EncodedRequest>,
-    writer_task_handle: JoinHandle<Result<(), (u32, CodecEncodeError)>>,
+    write_stream: FramedWrite<OwnedWriteHalf, ClientCodec>,
+    //writer_tx: mpsc::Sender<EncodedRequest>,
+    //writer_task_handle: JoinHandle<Result<(), (u32, CodecEncodeError)>>,
     data: ConnectionData,
 }
 
@@ -221,13 +220,13 @@ impl Connection {
             .await?;
         }
 
-        let (writer_tx, writer_rx) = mpsc::channel(1100);
-        let writer_task_handle = tokio::spawn(writer_task(writer_rx, write_stream));
+        //let writer_task_handle = tokio::spawn(writer_task(writer_rx, write_stream));
 
         let this = Self {
             read_stream,
-            writer_tx,
-            writer_task_handle,
+            //writer_tx,
+            write_stream,
+            //writer_task_handle,
             data: conn_data,
         };
 
@@ -320,25 +319,18 @@ impl Connection {
     ) -> Result<(), ()> {
         let Self {
             mut read_stream,
-            writer_tx,
-            mut writer_task_handle,
+            mut write_stream,
+            // writer_tx,
+            // mut writer_task_handle,
             mut data,
         } = self;
 
         let client_rx_filtered = client_rx.filter(|(_, tx)| ready(!tx.is_closed()));
         pin!(client_rx_filtered);
 
-        let mut next_request_to_write = None;
-        let mut permit: Option<Permit<_>> = None;
+        let mut send_future = Fuse::terminated();
 
         let err = loop {
-            if next_request_to_write.is_some() && permit.is_some() {
-                permit
-                    .take()
-                    .unwrap()
-                    .send(next_request_to_write.take().unwrap());
-            }
-
             tokio::select! {
                 // Read value from TCP stream
                 next = Connection::get_next_stream_value(&mut read_stream) => {
@@ -347,19 +339,8 @@ impl Connection {
                         Err(err) => break err,
                     }
                 }
-                // Get permit to send request to writer
-                permit_res = writer_tx.reserve(), if permit.is_none() => {
-                    match permit_res {
-                        Ok(x) => {
-                            permit = Some(x);
-                        },
-                        Err(err) => {
-                            todo!("throw error");
-                        }
-                    }
-                }
                 // Read value from internal queue
-                next = client_rx_filtered.next(), if next_request_to_write.is_none() => {
+                next = client_rx_filtered.next(), if send_future.is_terminated() => {
                     if let Some((mut request, tx)) = next {
                         // If failed to prepare request - just go to next
                         if data
@@ -370,29 +351,18 @@ impl Connection {
                         }
 
                         let sync = request.sync;
-                        next_request_to_write = Some(request);
-                        // let _send_res = writer_tx.send(request).await;
-                        // // FIXME: Ok(())
-                        // if let Err(err) = Connection::handle_send_result(&mut data, sync, Ok(())) {
-                        //     break err.into();
-                        // }
+                        send_future = write_stream.send(request).map(move |res| (sync, res)).fuse();
                     } else {
                         // TODO: actually don't quit until all in-flights processed
                         debug!("All senders dropped");
                         return Ok(());
                     }
                 }
-                writer_result = &mut writer_task_handle => {
-                    match writer_result {
-                        Err(_) => {
-                            todo!("handle result")
-                        },
-                        Ok(Err((sync, err))) => {
-                            todo!("handle result")
-                        },
-                        _ => {}
+                (sync, res) = &mut send_future => {
+                    // TODO: check result correctness
+                    if let Err(err) = Connection::handle_send_result(&mut data, sync, res) {
+                        break err.into();
                     }
-                    break CodecDecodeError::Closed
                 }
             }
         };

--- a/src/transport/connection.rs
+++ b/src/transport/connection.rs
@@ -5,16 +5,23 @@ use std::{
     time::Duration,
 };
 
-use futures::{SinkExt, TryStreamExt};
+use futures::{future::pending, Future, SinkExt, TryStreamExt};
 use tokio::{
     io::AsyncReadExt,
-    net::{TcpStream, ToSocketAddrs},
-    sync::oneshot,
+    net::{
+        tcp::{OwnedReadHalf, OwnedWriteHalf},
+        TcpStream, ToSocketAddrs,
+    },
+    pin,
+    sync::{mpsc, oneshot},
 };
-use tokio_util::codec::Framed;
+use tokio_util::{
+    codec::{Framed, FramedRead, FramedWrite},
+    either::Either,
+};
 use tracing::{debug, trace, warn};
 
-use super::dispatcher::DispatcherResponse;
+use super::dispatcher::{DispatcherRequest, DispatcherResponse};
 use crate::{
     codec::{
         request::{Auth, EncodedRequest},
@@ -25,9 +32,10 @@ use crate::{
 };
 
 pub(crate) struct Connection {
-    stream: Framed<TcpStream, ClientCodec>,
+    read_stream: Option<FramedRead<OwnedReadHalf, ClientCodec>>,
+    write_stream: Option<FramedWrite<OwnedWriteHalf, ClientCodec>>,
     in_flights: HashMap<u32, oneshot::Sender<DispatcherResponse>>,
-    next_sync: AtomicU32,
+    next_sync: u32,
 }
 
 // TODO: cancel
@@ -50,15 +58,28 @@ impl Connection {
         debug!("Server: {}", greeting.server);
         trace!("Salt: {:?}", greeting.salt);
 
-        let mut this = Self {
-            stream: Framed::new(tcp, ClientCodec::default()),
-            in_flights: HashMap::with_capacity(5),
-            next_sync: AtomicU32::new(0),
-        };
+        let (read_tcp_stream, write_tcp_stream) = tcp.into_split();
+        let mut read_stream = FramedRead::new(read_tcp_stream, ClientCodec::default());
+        let mut write_stream = FramedWrite::new(write_tcp_stream, ClientCodec::default());
 
         if let Some(user) = user {
-            this.auth(user, password, &greeting.salt).await?;
+            Self::auth(
+                &mut read_stream,
+                &mut write_stream,
+                0,
+                user,
+                password,
+                &greeting.salt,
+            )
+            .await?;
         }
+
+        let this = Self {
+            read_stream: Some(read_stream),
+            write_stream: Some(write_stream),
+            in_flights: HashMap::with_capacity(5),
+            next_sync: 0,
+        };
 
         Ok(this)
     }
@@ -81,14 +102,21 @@ impl Connection {
         }
     }
 
-    async fn auth(&mut self, user: &str, password: Option<&str>, salt: &[u8]) -> Result<(), Error> {
+    async fn auth(
+        read_stream: &mut FramedRead<OwnedReadHalf, ClientCodec>,
+        write_stream: &mut FramedWrite<OwnedWriteHalf, ClientCodec>,
+        sync: u32,
+        user: &str,
+        password: Option<&str>,
+        salt: &[u8],
+    ) -> Result<(), Error> {
         let mut request = EncodedRequest::new(Auth::new(user, password, salt), None).unwrap();
-        *request.sync_mut() = self.next_sync();
+        *request.sync_mut() = sync;
 
         trace!("Sending auth request");
-        self.stream.send(request).await?;
+        write_stream.send(request).await?;
 
-        let resp = self.get_next_stream_value().await?;
+        let resp = Self::get_next_stream_value2(read_stream).await?;
         match resp.body {
             ResponseBody::Ok(_x) => Ok(()),
             ResponseBody::Error(err) => Err(Error::Auth(err)),
@@ -96,15 +124,65 @@ impl Connection {
     }
 
     // TODO: maybe other Ordering??
-    fn next_sync(&self) -> u32 {
-        self.next_sync.fetch_add(1, Ordering::SeqCst)
+    fn next_sync(&mut self) -> u32 {
+        let next = self.next_sync;
+        self.next_sync += 1;
+        next
     }
 
-    pub(super) async fn send_request(
+    // pub(super) async fn send_request(
+    //     &mut self,
+    //     mut request: EncodedRequest,
+    //     tx: oneshot::Sender<DispatcherResponse>,
+    // ) -> Result<(), tokio::io::Error> {
+    //     let sync = self.next_sync();
+    //     *request.sync_mut() = sync;
+    //     trace!(
+    //         "Sending request with sync {}, stream_id {:?}",
+    //         request.sync,
+    //         request.stream_id
+    //     );
+    //     // TODO: replace with try_insert when stabilized
+    //     // If sync already assigned to another request, return an error
+    //     // for current request
+    //     if let Some(old) = self.in_flights.insert(request.sync, tx) {
+    //         let new = self
+    //             .in_flights
+    //             .insert(request.sync, old)
+    //             .expect("Shouldn't panic, value was just inserted");
+    //         if new.send(Err(Error::DuplicatedSync(request.sync))).is_err() {
+    //             warn!(
+    //                 "Failed to pass error to sync {}, receiver dropped",
+    //                 request.sync
+    //             );
+    //         }
+    //         return Ok(());
+    //     }
+    //     match self.write_stream.send(request).await {
+    //         Ok(x) => Ok(x),
+    //         Err(CodecEncodeError::Encode(err)) => {
+    //             if self
+    //                 .in_flights
+    //                 .remove(&sync)
+    //                 .expect("Shouldn't panic, value was just inserted")
+    //                 .send(Err(err.into()))
+    //                 .is_err()
+    //             {
+    //                 warn!("Failed to pass error to sync {}, receiver dropped", sync);
+    //             }
+    //             Ok(())
+    //         }
+    //         Err(CodecEncodeError::Io(err)) => Err(err),
+    //     }
+    // }
+
+    // Return false if request shouldn't be sent and should be dropped
+    // instead
+    fn prepare_request(
         &mut self,
-        mut request: EncodedRequest,
+        request: &mut EncodedRequest,
         tx: oneshot::Sender<DispatcherResponse>,
-    ) -> Result<(), tokio::io::Error> {
+    ) -> bool {
         let sync = self.next_sync();
         *request.sync_mut() = sync;
         trace!(
@@ -126,9 +204,17 @@ impl Connection {
                     request.sync
                 );
             }
-            return Ok(());
+            return false;
         }
-        match self.stream.send(request).await {
+        true
+    }
+
+    fn handle_send_result(
+        &mut self,
+        sync: u32,
+        result: Result<(), CodecEncodeError>,
+    ) -> Result<(), tokio::io::Error> {
+        match result {
             Ok(x) => Ok(x),
             Err(CodecEncodeError::Encode(err)) => {
                 if self
@@ -157,23 +243,42 @@ impl Connection {
         }
     }
 
-    async fn get_next_stream_value(&mut self) -> Result<Response, CodecDecodeError> {
-        match self.stream.try_next().await {
+    // async fn get_next_stream_value(&mut self) -> Result<Response, CodecDecodeError> {
+    //     match self.read_stream.try_next().await {
+    //         Ok(Some(x)) => Ok(x),
+    //         Ok(None) => Err(CodecDecodeError::Closed),
+    //         Err(e) => Err(e),
+    //     }
+    // }
+
+    async fn get_next_stream_value2(
+        read_stream: &mut FramedRead<OwnedReadHalf, ClientCodec>,
+    ) -> Result<Response, CodecDecodeError> {
+        match read_stream.try_next().await {
             Ok(Some(x)) => Ok(x),
             Ok(None) => Err(CodecDecodeError::Closed),
             Err(e) => Err(e),
         }
     }
 
-    pub(super) async fn handle_next_response(&mut self) -> Result<(), CodecDecodeError> {
-        let resp = self.get_next_stream_value().await?;
+    // pub(super) async fn handle_next_response(&mut self) -> Result<(), CodecDecodeError> {
+    //     let resp = self.get_next_stream_value().await?;
+    //     trace!(
+    //         "Received response for sync {}, schema version {}",
+    //         resp.sync,
+    //         resp.schema_version
+    //     );
+    //     self.pass_response(resp);
+    //     Ok(())
+    // }
+
+    fn handle_response(&mut self, response: Response) {
         trace!(
             "Received response for sync {}, schema version {}",
-            resp.sync,
-            resp.schema_version
+            response.sync,
+            response.schema_version
         );
-        self.pass_response(resp);
-        Ok(())
+        self.pass_response(response);
     }
 
     /// Send error to all in flight requests and drop current transport.
@@ -181,5 +286,53 @@ impl Connection {
         for (_, tx) in self.in_flights.drain() {
             let _ = tx.send(Err(err.clone().into()));
         }
+    }
+
+    pub(crate) async fn run(mut self, rx: &mut mpsc::Receiver<DispatcherRequest>) -> bool {
+        let mut write_stream = self.write_stream.take();
+        let mut read_stream = self.read_stream.take().unwrap();
+
+        let send_fut = Either::Left(pending());
+        pin!(send_fut);
+
+        let err = loop {
+            tokio::select! {
+                next = Self::get_next_stream_value2(&mut read_stream) => {
+                    match next {
+                        Ok(x) => self.handle_response(x),
+                        Err(err) => break err,
+                    }
+                }
+                next = rx.recv(), if write_stream.is_some() => {
+                    if let Some((mut request, tx)) = next {
+                        // Check whether tx is closed in case someone cancelled request
+                        // while it was in queue
+                        if !tx.is_closed() {
+                            if self.prepare_request(&mut request, tx) {
+                                let mut write_stream_ = write_stream.take().unwrap();
+                                send_fut.set(Either::Right(async move {
+                                    let sync = request.sync;
+                                    let send_res = write_stream_.send(request).await;
+                                    (send_res, sync, write_stream_)
+                                }));
+                            }
+                        }
+                    } else {
+                        debug!("All senders dropped");
+                        return true
+                    }
+                }
+                (send_res, sync, write_stream_) = &mut send_fut => {
+                    send_fut.set(Either::Left(pending()));
+                    write_stream = Some(write_stream_);
+
+                    if let Err(err) = self.handle_send_result(sync, send_res) {
+                        break err.into();
+                    }
+                }
+            }
+        };
+        self.finish_with_error(err);
+        false
     }
 }

--- a/src/transport/dispatcher.rs
+++ b/src/transport/dispatcher.rs
@@ -56,6 +56,7 @@ impl Dispatcher {
         password: Option<&str>,
         connect_timeout: Option<Duration>,
         reconnect_interval: Option<ReconnectInterval>,
+        dispatcher_internal_queue_size: usize,
     ) -> Result<(Self, DispatcherSender), Error>
     where
         A: ToSocketAddrs + Display + Clone + Send + Sync + 'static,
@@ -74,8 +75,7 @@ impl Dispatcher {
 
         let conn = conn_factory().await?;
 
-        // TODO: test whether increased size can help with performance
-        let (tx, rx) = mpsc::channel(1);
+        let (tx, rx) = mpsc::channel(dispatcher_internal_queue_size);
 
         Ok((
             Self {

--- a/src/transport/dispatcher.rs
+++ b/src/transport/dispatcher.rs
@@ -1,16 +1,22 @@
-use std::{fmt::Display, future::Future, pin::Pin, time::Duration};
+use std::{fmt::Display, future::Future, pin::Pin, process::Output, time::Duration};
 
 use backoff::{backoff::Backoff, ExponentialBackoff, ExponentialBackoffBuilder};
-use futures::TryFutureExt;
+use futures::{Stream, TryFutureExt, TryStreamExt};
 use tokio::{
-    net::ToSocketAddrs,
+    io::AsyncReadExt,
+    net::{
+        tcp::{OwnedReadHalf, OwnedWriteHalf},
+        TcpStream, ToSocketAddrs,
+    },
     sync::{mpsc, oneshot},
 };
-use tracing::{debug, error};
+use tokio_util::codec::{FramedRead, FramedWrite};
+use tracing::{debug, error, trace};
 
 use super::connection::Connection;
 use crate::{
-    codec::{request::EncodedRequest, response::Response},
+    codec::{request::EncodedRequest, response::Response, ClientCodec, Greeting},
+    errors::CodecDecodeError,
     Error, ReconnectInterval,
 };
 
@@ -44,7 +50,7 @@ type ConnectDynFuture = dyn Future<Output = Result<Connection, Error>> + Send;
 /// Currently no-op, in future it should handle reconnects, schema reloading, pooling.
 pub(crate) struct Dispatcher {
     rx: mpsc::Receiver<DispatcherRequest>,
-    conn: Connection,
+    conn: Option<Connection>,
     conn_factory: Box<dyn Fn() -> Pin<Box<ConnectDynFuture>> + Send + Sync>,
     reconnect_interval: Option<ReconnectInterval>,
 }
@@ -57,7 +63,7 @@ impl Dispatcher {
         connect_timeout: Option<Duration>,
         reconnect_interval: Option<ReconnectInterval>,
         dispatcher_internal_queue_size: usize,
-    ) -> Result<(Self, DispatcherSender), Error>
+    ) -> Result<(impl Future<Output = ()>, DispatcherSender), Error>
     where
         A: ToSocketAddrs + Display + Clone + Send + Sync + 'static,
     {
@@ -80,10 +86,11 @@ impl Dispatcher {
         Ok((
             Self {
                 rx,
-                conn,
+                conn: Some(conn),
                 conn_factory,
                 reconnect_interval,
-            },
+            }
+            .run(),
             DispatcherSender { tx },
         ))
     }
@@ -96,7 +103,7 @@ impl Dispatcher {
         loop {
             match (self.conn_factory)().await {
                 Ok(conn) => {
-                    self.conn = conn;
+                    self.conn = Some(conn);
                     return;
                 }
                 Err(err) => {
@@ -112,39 +119,14 @@ impl Dispatcher {
     pub(crate) async fn run(mut self) {
         debug!("Starting dispatcher");
         loop {
-            if self.run_conn().await {
-                return;
+            if let Some(conn) = self.conn.take() {
+                if conn.run(&mut self.rx).await {
+                    return;
+                }
+            } else {
+                self.reconnect().await;
             }
-            self.reconnect().await;
         }
-    }
-
-    pub(crate) async fn run_conn(&mut self) -> bool {
-        let err = loop {
-            tokio::select! {
-                next = self.conn.handle_next_response() => {
-                    if let Err(e) = next {
-                        break e;
-                    }
-                }
-                next = self.rx.recv() => {
-                    if let Some((request, tx)) = next {
-                        // Check whether tx is closed in case someone cancelled request
-                        // while it was in queue
-                        if !tx.is_closed() {
-                            if let Err(err) = self.conn.send_request(request, tx).await {
-                                break err.into();
-                            }
-                        }
-                    } else {
-                        debug!("All senders dropped");
-                        return true
-                    }
-                }
-            }
-        };
-        self.conn.finish_with_error(err);
-        false
     }
 }
 

--- a/src/transport/dispatcher.rs
+++ b/src/transport/dispatcher.rs
@@ -6,6 +6,7 @@ use tokio::{
     net::ToSocketAddrs,
     sync::{mpsc, oneshot},
 };
+use tokio_stream::wrappers::ReceiverStream;
 use tracing::{debug, error};
 
 use super::connection::Connection;
@@ -43,7 +44,7 @@ type ConnectDynFuture = dyn Future<Output = Result<Connection, Error>> + Send;
 ///
 /// Currently no-op, in future it should handle reconnects, schema reloading, pooling.
 pub(crate) struct Dispatcher {
-    rx: mpsc::Receiver<DispatcherRequest>,
+    rx: ReceiverStream<DispatcherRequest>,
     conn: Option<Connection>,
     conn_factory: Box<dyn Fn() -> Pin<Box<ConnectDynFuture>> + Send + Sync>,
     reconnect_interval: Option<ReconnectInterval>,
@@ -79,7 +80,7 @@ impl Dispatcher {
 
         Ok((
             Self {
-                rx,
+                rx: ReceiverStream::new(rx),
                 conn: Some(conn),
                 conn_factory,
                 reconnect_interval,


### PR DESCRIPTION
This merge request improves performance of this crate and separates reading and writing TCP socket into separate tasks.

I tested multiple approaches (removing trait objects, using single or different tasks for reading and writing TCP socket, ...) and came to following conclusions

1. Currently dyn Traits can take up to 7% of the CPU (harold_hides_pain.jpg). Waiting for async trait to be stabilized;
2. Using single task for working with TCP stream might slightly improve latency (5-10%) on small traffic, but will be significantly worse on big traffic (30%+).